### PR TITLE
Modernize `tox.ini` syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,16 +61,14 @@ strict_equality = true
 pretty = true
 show_error_codes = true
 
-[tool.ruff]
-target-version = "py312"
-extend-include = ["*.ipynb"]
-
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --random-order-seed=0 --cov-report=xml --cov-report=term --cov-append"
 minversion = "8.0"
 required_plugins = "pytest-random-order pytest-cov"
 xfail_strict = true
 
+
+# Ruff config
 [tool.ruff.lint]
 extend-select = ["ALL"]
 ignore = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,16 @@
 [tox]
-envlist = py3.{10,11,12}-{pytest,pre-commit}
+envlist = py3.{10-12}-{pytest,pre-commit}
+min_version = 4.25
 
-[testenv:py3.{10,11,12}-pytest]
+[testenv]
 commands =
-    # https://jugmac00.github.io/til/how-to-bring-color-back-into-tox-and-pytest/
-    pytest {tty:--color=yes} {posargs}
+    pytest: pytest {tty:--color=yes} {posargs}
+    pre-commit: pre-commit run  {tty:--color=always} -a
 deps =
-    pytest
-    pytest-cov
-    pytest-random-order
-    pytest-xdist
+    pre-commit: pre-commit
+    pytest: pytest
+    pytest: pytest-cov
+    pytest: pytest-random-order
+    pytest: pytest-xdist
 
-[testenv:py3.{10,11,12}-pre-commit]
-commands =
-    pre-commit run  {tty:--color=always} -a
-deps =
-    pre-commit
-skip_install = true
+skip_install = pre-commit: true


### PR DESCRIPTION
No change in functionality, but now it uses the newer INI syntax.